### PR TITLE
Changes to allow timezone to be configured

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,6 +84,7 @@ defaultPortal = {
     "custom genres": {},
     "custom epg ids": {},
     "fallback channels": {},
+    "time_zone": "Europe/London",
 }
 
 
@@ -205,6 +206,7 @@ def portalsAdd():
     macs = list(set(request.form["macs"].split(",")))
     streamsPerMac = request.form["streams per mac"]
     proxy = request.form["proxy"]
+    time_zone = request.form["time_zone"]
 
     if not url.endswith(".php"):
         url = stb.getUrl(url, proxy)
@@ -216,10 +218,10 @@ def portalsAdd():
     macsd = {}
 
     for mac in macs:
-        token = stb.getToken(url, mac, proxy)
+        token = stb.getToken(url, mac, proxy, time_zone)
         if token:
-            stb.getProfile(url, mac, token, proxy)
-            expiry = stb.getExpires(url, mac, token, proxy)
+            stb.getProfile(url, mac, token, proxy, time_zone)
+            expiry = stb.getExpires(url, mac, token, proxy, time_zone)
             if expiry:
                 macsd[mac] = expiry
                 logger.info(
@@ -242,6 +244,7 @@ def portalsAdd():
             "macs": macsd,
             "streams per mac": streamsPerMac,
             "proxy": proxy,
+            "time_zone": time_zone,
         }
 
         for setting, default in defaultPortal.items():
@@ -273,6 +276,7 @@ def portalUpdate():
     newmacs = list(set(request.form["macs"].split(",")))
     streamsPerMac = request.form["streams per mac"]
     proxy = request.form["proxy"]
+    time_zone = request.form["time_zone"]
     retest = request.form.get("retest", None)
 
     if not url.endswith(".php"):
@@ -289,10 +293,10 @@ def portalUpdate():
 
     for mac in newmacs:
         if retest or mac not in oldmacs.keys():
-            token = stb.getToken(url, mac, proxy)
+            token = stb.getToken(url, mac, proxy, time_zone)
             if token:
-                stb.getProfile(url, mac, token, proxy)
-                expiry = stb.getExpires(url, mac, token, proxy)
+                stb.getProfile(url, mac, token, proxy, time_zone)
+                expiry = stb.getExpires(url, mac, token, proxy, time_zone)
                 if expiry:
                     macsout[mac] = expiry
                     logger.info(
@@ -320,6 +324,7 @@ def portalUpdate():
         portals[id]["macs"] = macsout
         portals[id]["streams per mac"] = streamsPerMac
         portals[id]["proxy"] = proxy
+        portals[id]["time_zone"] = time_zone
         savePortals(portals)
         logger.info("Portal({}) updated!".format(name))
         flash("Portal({}) updated!".format(name), "success")
@@ -364,6 +369,7 @@ def editor_data():
             url = portals[portal]["url"]
             macs = list(portals[portal]["macs"].keys())
             proxy = portals[portal]["proxy"]
+            time_zone = portals[portal]["time_zone"]
             enabledChannels = portals[portal].get("enabled channels", [])
             customChannelNames = portals[portal].get("custom channel names", {})
             customGenres = portals[portal].get("custom genres", {})
@@ -373,10 +379,10 @@ def editor_data():
 
             for mac in macs:
                 try:
-                    token = stb.getToken(url, mac, proxy)
-                    stb.getProfile(url, mac, token, proxy)
-                    allChannels = stb.getAllChannels(url, mac, token, proxy)
-                    genres = stb.getGenreNames(url, mac, token, proxy)
+                    token = stb.getToken(url, mac, proxy, time_zone)
+                    stb.getProfile(url, mac, token, proxy, time_zone)
+                    allChannels = stb.getAllChannels(url, mac, token, proxy, time_zone)
+                    genres = stb.getGenreNames(url, mac, token, proxy, time_zone)
                     break
                 except:
                     allChannels = None
@@ -579,6 +585,7 @@ def playlist():
                 url = portals[portal]["url"]
                 macs = list(portals[portal]["macs"].keys())
                 proxy = portals[portal]["proxy"]
+                time_zone = portals[portal]["time_zone"]
                 customChannelNames = portals[portal].get("custom channel names", {})
                 customGenres = portals[portal].get("custom genres", {})
                 customChannelNumbers = portals[portal].get("custom channel numbers", {})
@@ -586,10 +593,10 @@ def playlist():
 
                 for mac in macs:
                     try:
-                        token = stb.getToken(url, mac, proxy)
-                        stb.getProfile(url, mac, token, proxy)
-                        allChannels = stb.getAllChannels(url, mac, token, proxy)
-                        genres = stb.getGenreNames(url, mac, token, proxy)
+                        token = stb.getToken(url, mac, proxy, time_zone)
+                        stb.getProfile(url, mac, token, proxy, time_zone)
+                        allChannels = stb.getAllChannels(url, mac, token, proxy, time_zone)
+                        genres = stb.getGenreNames(url, mac, token, proxy, time_zone)
                         break
                     except:
                         allChannels = None
@@ -670,15 +677,16 @@ def xmltv():
                 url = portals[portal]["url"]
                 macs = list(portals[portal]["macs"].keys())
                 proxy = portals[portal]["proxy"]
+                time_zone = portals[portal]["time_zone"]
                 customChannelNames = portals[portal].get("custom channel names", {})
                 customEpgIds = portals[portal].get("custom epg ids", {})
 
                 for mac in macs:
                     try:
-                        token = stb.getToken(url, mac, proxy)
-                        stb.getProfile(url, mac, token, proxy)
-                        allChannels = stb.getAllChannels(url, mac, token, proxy)
-                        epg = stb.getEpg(url, mac, token, 24, proxy)
+                        token = stb.getToken(url, mac, proxy, time_zone)
+                        stb.getProfile(url, mac, token, proxy, time_zone)
+                        allChannels = stb.getAllChannels(url, mac, token, proxy, time_zone)
+                        epg = stb.getEpg(url, mac, token, 24, proxy, time_zone)
                         break
                     except:
                         allChannels = None
@@ -834,6 +842,7 @@ def channel(portalId, channelId):
     url = portal.get("url")
     macs = list(portal["macs"].keys())
     streamsPerMac = int(portal.get("streams per mac"))
+    time_zone = portal.get("time_zone")
     proxy = portal.get("proxy")
     web = request.args.get("web")
     ip = request.remote_addr
@@ -853,10 +862,10 @@ def channel(portalId, channelId):
                 "Trying Portal({}):MAC({}):Channel({})".format(portalId, mac, channelId)
             )
             freeMac = True
-            token = stb.getToken(url, mac, proxy)
+            token = stb.getToken(url, mac, proxy, time_zone)
             if token:
-                stb.getProfile(url, mac, token, proxy)
-                channels = stb.getAllChannels(url, mac, token, proxy)
+                stb.getProfile(url, mac, token, proxy, time_zone)
+                channels = stb.getAllChannels(url, mac, token, proxy, time_zone)
 
         if channels:
             for c in channels:
@@ -869,7 +878,7 @@ def channel(portalId, channelId):
 
         if cmd:
             if "http://localhost/" in cmd:
-                link = stb.getLink(url, mac, token, cmd, proxy)
+                link = stb.getLink(url, mac, token, cmd, proxy, time_zone)
             else:
                 link = cmd.split(" ")[1]
 
@@ -941,6 +950,7 @@ def channel(portalId, channelId):
                     url = portals[portal].get("url")
                     macs = list(portals[portal]["macs"].keys())
                     proxy = portals[portal].get("proxy")
+                    time_zone = portal[portal].get("time_zone")
                     for mac in macs:
                         channels = None
                         cmd = None
@@ -949,10 +959,10 @@ def channel(portalId, channelId):
                             for k, v in fallbackChannels.items():
                                 if v == channelName:
                                     try:
-                                        token = stb.getToken(url, mac, proxy)
-                                        stb.getProfile(url, mac, token, proxy)
+                                        token = stb.getToken(url, mac, proxy, time_zone)
+                                        stb.getProfile(url, mac, token, proxy, time_zone)
                                         channels = stb.getAllChannels(
-                                            url, mac, token, proxy
+                                            url, mac, token, proxy, time_zone
                                         )
                                     except:
                                         logger.info(
@@ -969,7 +979,7 @@ def channel(portalId, channelId):
                                         if cmd:
                                             if "http://localhost/" in cmd:
                                                 link = stb.getLink(
-                                                    url, mac, token, cmd, proxy
+                                                    url, mac, token, cmd, proxy, time_zone
                                                 )
                                             else:
                                                 link = cmd.split(" ")[1]
@@ -1135,14 +1145,15 @@ def lineup():
                 url = portals[portal]["url"]
                 macs = list(portals[portal]["macs"].keys())
                 proxy = portals[portal]["proxy"]
+                time_zone = portals[portal]["time_zone"]
                 customChannelNames = portals[portal].get("custom channel names", {})
                 customChannelNumbers = portals[portal].get("custom channel numbers", {})
 
                 for mac in macs:
                     try:
-                        token = stb.getToken(url, mac, proxy)
-                        stb.getProfile(url, mac, token, proxy)
-                        allChannels = stb.getAllChannels(url, mac, token, proxy)
+                        token = stb.getToken(url, mac, proxy, time_zone)
+                        stb.getProfile(url, mac, token, proxy, time_zone)
+                        allChannels = stb.getAllChannels(url, mac, token, proxy, time_zone)
                         break
                     except:
                         allChannels = None

--- a/stb.py
+++ b/stb.py
@@ -63,9 +63,9 @@ def getUrl(url, proxy=None):
         pass
 
 
-def getToken(url, mac, proxy=None):
+def getToken(url, mac, proxy=None, t_zone=None):
     proxies = {"http": proxy, "https": proxy}
-    cookies = {"mac": mac, "stb_lang": "en", "timezone": "Europe/London"}
+    cookies = {"mac": mac, "stb_lang": "en", "timezone": t_zone}
     headers = {"User-Agent": "Mozilla/5.0 (QtEmbedded; U; Linux; C)"}
     try:
         response = s.get(
@@ -81,9 +81,9 @@ def getToken(url, mac, proxy=None):
         pass
 
 
-def getProfile(url, mac, token, proxy=None):
+def getProfile(url, mac, token, proxy=None, t_zone=None):
     proxies = {"http": proxy, "https": proxy}
-    cookies = {"mac": mac, "stb_lang": "en", "timezone": "Europe/London"}
+    cookies = {"mac": mac, "stb_lang": "en", "timezone": t_zone}
     headers = {
         "User-Agent": "Mozilla/5.0 (QtEmbedded; U; Linux; C)",
         "Authorization": "Bearer " + token,
@@ -102,9 +102,9 @@ def getProfile(url, mac, token, proxy=None):
         pass
 
 
-def getExpires(url, mac, token, proxy=None):
+def getExpires(url, mac, token, proxy=None, t_zone=None):
     proxies = {"http": proxy, "https": proxy}
-    cookies = {"mac": mac, "stb_lang": "en", "timezone": "Europe/London"}
+    cookies = {"mac": mac, "stb_lang": "en", "timezone": t_zone}
     headers = {
         "User-Agent": "Mozilla/5.0 (QtEmbedded; U; Linux; C)",
         "Authorization": "Bearer " + token,
@@ -123,9 +123,9 @@ def getExpires(url, mac, token, proxy=None):
         pass
 
 
-def getAllChannels(url, mac, token, proxy=None):
+def getAllChannels(url, mac, token, proxy=None, t_zone=None):
     proxies = {"http": proxy, "https": proxy}
-    cookies = {"mac": mac, "stb_lang": "en", "timezone": "Europe/London"}
+    cookies = {"mac": mac, "stb_lang": "en", "timezone": t_zone}
     headers = {
         "User-Agent": "Mozilla/5.0 (QtEmbedded; U; Linux; C)",
         "Authorization": "Bearer " + token,
@@ -145,9 +145,9 @@ def getAllChannels(url, mac, token, proxy=None):
         pass
 
 
-def getGenres(url, mac, token, proxy=None):
+def getGenres(url, mac, token, proxy=None, t_zone=None):
     proxies = {"http": proxy, "https": proxy}
-    cookies = {"mac": mac, "stb_lang": "en", "timezone": "Europe/London"}
+    cookies = {"mac": mac, "stb_lang": "en", "timezone": t_zone}
     headers = {
         "User-Agent": "Mozilla/5.0 (QtEmbedded; U; Linux; C)",
         "Authorization": "Bearer " + token,
@@ -166,9 +166,9 @@ def getGenres(url, mac, token, proxy=None):
         pass
 
 
-def getGenreNames(url, mac, token, proxy=None):
+def getGenreNames(url, mac, token, proxy=None, t_zone=None):
     try:
-        genreData = getGenres(url, mac, token, proxy)
+        genreData = getGenres(url, mac, token, proxy, t_zone)
         genres = {}
         for i in genreData:
             gid = i["id"]
@@ -180,9 +180,9 @@ def getGenreNames(url, mac, token, proxy=None):
         pass
 
 
-def getLink(url, mac, token, cmd, proxy=None):
+def getLink(url, mac, token, cmd, proxy=None, t_zone=None):
     proxies = {"http": proxy, "https": proxy}
-    cookies = {"mac": mac, "stb_lang": "en", "timezone": "Europe/London"}
+    cookies = {"mac": mac, "stb_lang": "en", "timezone": t_zone}
     headers = {
         "User-Agent": "Mozilla/5.0 (QtEmbedded; U; Linux; C)",
         "Authorization": "Bearer " + token,
@@ -205,9 +205,9 @@ def getLink(url, mac, token, cmd, proxy=None):
         pass
 
 
-def getEpg(url, mac, token, period, proxy=None):
+def getEpg(url, mac, token, period, proxy=None, t_zone=None):
     proxies = {"http": proxy, "https": proxy}
-    cookies = {"mac": mac, "stb_lang": "en", "timezone": "Europe/London"}
+    cookies = {"mac": mac, "stb_lang": "en", "timezone": t_zone}
     headers = {
         "User-Agent": "Mozilla/5.0 (QtEmbedded; U; Linux; C)",
         "Authorization": "Bearer " + token,

--- a/templates/portals.html
+++ b/templates/portals.html
@@ -24,6 +24,7 @@
                     data-url="{{ portals[portal].url }}" data-proxy="{{ portals[portal].proxy }}"
                     data-macs="{{ portals[portal].macs|join(',') }}"
                     data-streamsPerMac="{{ portals[portal]['streams per mac'] }}" data-bs-toggle="modal"
+                    data-time_zone="{{ portals[portal]['time_zone'] }}"
                     data-bs-target="#modalEdit">
                     <i class="me-2 fa fa-server"{{ "hidden" if portals[portal].enabled =='false' }}></i>
                     <i class="me-2 fa fa-ban"{{ "hidden" if portals[portal].enabled =='true' }}></i>
@@ -94,6 +95,12 @@
                     <input type="number" name="streams per mac" class="form-control flex-fill" title="Streams Per Mac"
                         min="0" value="1" required>
                     <span class="text-muted">How many streams does each MAC allow. 0 = unlimited.</span>
+                    
+                    <br><br>
+
+                    <h6>Timezone:</h6>
+                    <input type="text" name="time_zone" class="form-control flex-fill" title="Timezone" value="Europe/London">
+                    <span class="text-muted">Optional Timezone.</span>
 
                     <br><br>
 
@@ -160,6 +167,12 @@
 
                     <br><br>
 
+                    <h6>Timezone:</h6>
+                    <input type="text" name="time_zone" id="editTimeZone" class="form-control flex-fill" title="Timezone" > 
+                    <span class="text-muted">Optional Timezone.</span>
+
+                    <br><br>
+
                     <div class="modal-footer">
                         <button class="btn btn-danger me-auto" title="Delete" form="delete"
                             id="deleteName">Delete</button>
@@ -206,6 +219,7 @@
         var proxy = button.getAttribute('data-proxy');
         var macs = button.getAttribute('data-macs');
         var streamsPerMac = button.getAttribute('data-streamsPerMac');
+        var time_zone = button.getAttribute('data-time_zone');
         document.getElementById('editId').value = id;
         if (enabled == "true") {
             document.getElementById('editEnabled').checked = true;
@@ -217,6 +231,7 @@
         document.getElementById('editProxy').value = proxy;
         document.getElementById('editMacs').value = macs;
         document.getElementById('editStreamsPerMac').value = streamsPerMac;
+        document.getElementById('editTimeZone').value = time_zone;
         document.getElementById('deleteId').value = id;
         document.getElementById('deleteName').value = name;
         document.getElementById('retest').checked = false;


### PR DESCRIPTION
Still use a default timezone, and add abbility the timezone to be configured. Potentially it can be discovered from the portal default. As far as i know, some middlewares are comparing the desired timezone against whitelist one. So this can help in this scenario too.