### PR TITLE
Disable smart search and initiate search after pressing enter.

### DIFF
--- a/templates/editor.html
+++ b/templates/editor.html
@@ -176,6 +176,10 @@
             dom: "<'row m-1'<'col-auto'B><'col-auto ms-auto'f><'col-auto'l>>" +
                 "<'row'<'col-12'tr>>" +
                 "<'row mb-1 mb-lg-0'<'col-auto text-light'i><'col-auto ms-auto'p>>",
+            search: {
+                return: true,
+                smart: false,
+            },
             orderFixed: [0, 'des'],
             order: [[0, 'des'], [2, 'asc']],
             pageLength: 25,


### PR DESCRIPTION
This helps with the speed and responsivness, especially for slow browsers.
Also will benefit greatly for regex search ( or the search builder which jojo14185 is developing https://github.com/jojo141185/STB-Proxy)